### PR TITLE
Add CITATION.cff and contents

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 0.1.0
+cff-version: 1.2.0
 title: 'Workflomics pubmetric: Benchmarking Bioinformatics Workflows Using Bibliographic Networks'
 message: >-
   If you use this software, please cite it using the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,9 +20,6 @@ authors:
     email: n.m.palmblad@lumc.nl
     affiliation: Leiden University Medical Center, Netherlands
     orcid: 'https://orcid.org/0000-0002-5865-8994'
-identifiers:
-  - type: doi
-    value: -
 repository-code: 'https://github.com/Workflomics/pubmetric'
 url: 'https://github.com/Workflomics/pubmetric'
 abstract: >-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+cff-version: 0.1.0
+title: 'Workflomics pubmetric: Benchmarking Bioinformatics Workflows Using Bibliographic Networks'
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Alma
+    family-names: Nilsson
+    email: alma.as.nilsson@gmail.com
+    affiliation: Uppsala university, Sweden
+    orcid: ''
+  - given-names: Vedran
+    family-names: Kasalica
+    email: v.kasalica@esciencecenter.nl
+    affiliation: Netherlands eScience Center, Netherlands
+    orcid: 'https://orcid.org/0000-0002-0097-1056'
+  - given-names: Magnus
+    family-names: Palmblad
+    email: n.m.palmblad@lumc.nl
+    affiliation: Leiden University Medical Center, Netherlands
+    orcid: 'https://orcid.org/0000-0002-5865-8994'
+identifiers:
+  - type: doi
+    value: -
+repository-code: 'https://github.com/Workflomics/pubmetric'
+url: 'https://github.com/Workflomics/pubmetric'
+abstract: >-
+  This package provides a framework for benchmarking bioinformatics workflows using bibliographic networks, generating workflow and tool-level metrics based on co-citation data from bio.tools, Europe PMC, and NCBI.
+
+keywords:
+  - bioinformatics
+  - workflow benchmarking
+  - bibliometrics
+license: Apache-2.0


### PR DESCRIPTION
This PR closes #41. The contents were based on the CITATION.cff file in https://github.com/Workflomics/workflomics-benchmarker/blob/main/CITATION.cff, and perhaps identifiers should be entirely removed as I did not upload pubmetric to Zenodo? 

Best regards from Uppsala to the Workflomics team! 